### PR TITLE
Declare Unity runtime tools and migrate JSON handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ crashlytics-build.properties
 /[Aa]ssets/[Ss]treamingAssets/aa/*
 
 /Documentation~
+/.craft

--- a/Editor/AssemblyInfo.cs
+++ b/Editor/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("DotCraft.Editor.Tests")]

--- a/Editor/AssemblyInfo.cs.meta
+++ b/Editor/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: da994a6be3b240b0b69cb3f18732c767
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Connection/AcpClient.cs
+++ b/Editor/Connection/AcpClient.cs
@@ -522,7 +522,7 @@ namespace DotCraft.Editor.Connection
             });
 
             // Extension method handler for _unity/*
-            // Method name is passed separately - no longer injected into params
+            // Method name is passed separately from params.
             // Only register if built-in Unity tools are enabled
             if (_settings.EnableBuiltinUnityTools)
             {
@@ -542,7 +542,16 @@ namespace DotCraft.Editor.Connection
                 {
                     Fs = FsCapabilities.All,
                     Terminal = TerminalCapabilities.All,
-                    Extensions = _settings.EnableBuiltinUnityTools ? new[] { "_unity" } : Array.Empty<string>()
+                    Extensions = _settings.EnableBuiltinUnityTools ? new[] { "_unity" } : Array.Empty<string>(),
+                    Meta = _settings.EnableBuiltinUnityTools
+                        ? new ClientCapabilitiesMeta
+                        {
+                            DotCraft = new DotCraftClientCapabilities
+                            {
+                                RuntimeTools = BuildBuiltinUnityRuntimeTools()
+                            }
+                        }
+                        : null
                 },
                 ClientInfo = new ClientInfo
                 {
@@ -553,6 +562,98 @@ namespace DotCraft.Editor.Connection
 
             var result = await _transport.SendRequestAsync(AcpMethods.Initialize, @params, ct);
             return result.Deserialize<InitializeResult>(JsonOptions);
+        }
+
+        private static List<AcpRuntimeToolDescriptor> BuildBuiltinUnityRuntimeTools()
+        {
+            return new List<AcpRuntimeToolDescriptor>
+            {
+                new AcpRuntimeToolDescriptor
+                {
+                    Namespace = "unity",
+                    Name = "unity_scene_query",
+                    Description = "Query Unity scene hierarchy with optional component details.",
+                    InputSchema = ObjectSchema(new Dictionary<string, object>
+                    {
+                        ["query"] = new Dictionary<string, object>
+                        {
+                            ["type"] = "string",
+                            ["description"] = "Optional case-insensitive text to match against GameObject names or paths."
+                        },
+                        ["includeComponents"] = new Dictionary<string, object>
+                        {
+                            ["type"] = "boolean",
+                            ["description"] = "Include component type names for each returned GameObject."
+                        },
+                        ["maxDepth"] = new Dictionary<string, object>
+                        {
+                            ["type"] = "integer",
+                            ["minimum"] = 1,
+                            ["description"] = "Maximum hierarchy depth to include."
+                        }
+                    }),
+                    AcpMethod = "_unity/scene_query",
+                    Kind = AcpToolKind.Unity,
+                    DeferLoading = true
+                },
+                new AcpRuntimeToolDescriptor
+                {
+                    Namespace = "unity",
+                    Name = "unity_get_selection",
+                    Description = "Read the current Unity Editor selection.",
+                    InputSchema = ObjectSchema(new Dictionary<string, object>()),
+                    AcpMethod = "_unity/get_selection",
+                    Kind = AcpToolKind.Unity,
+                    DeferLoading = true
+                },
+                new AcpRuntimeToolDescriptor
+                {
+                    Namespace = "unity",
+                    Name = "unity_get_console_logs",
+                    Description = "Retrieve recent Unity Console log entries.",
+                    InputSchema = ObjectSchema(new Dictionary<string, object>
+                    {
+                        ["types"] = new Dictionary<string, object>
+                        {
+                            ["type"] = "array",
+                            ["description"] = "Optional log types to include.",
+                            ["items"] = new Dictionary<string, object>
+                            {
+                                ["type"] = "string",
+                                ["enum"] = new[] { "error", "warning", "log" }
+                            }
+                        },
+                        ["limit"] = new Dictionary<string, object>
+                        {
+                            ["type"] = "integer",
+                            ["minimum"] = 1,
+                            ["description"] = "Maximum number of recent entries to return."
+                        }
+                    }),
+                    AcpMethod = "_unity/get_console_logs",
+                    Kind = AcpToolKind.Unity,
+                    DeferLoading = true
+                },
+                new AcpRuntimeToolDescriptor
+                {
+                    Namespace = "unity",
+                    Name = "unity_get_project_info",
+                    Description = "Read Unity version, project name, project path, and package information.",
+                    InputSchema = ObjectSchema(new Dictionary<string, object>()),
+                    AcpMethod = "_unity/get_project_info",
+                    Kind = AcpToolKind.Unity,
+                    DeferLoading = true
+                }
+            };
+        }
+
+        private static Dictionary<string, object> ObjectSchema(Dictionary<string, object> properties)
+        {
+            return new Dictionary<string, object>
+            {
+                ["type"] = "object",
+                ["properties"] = properties
+            };
         }
 
         private async Task<SessionNewResult> NewSessionAsync(CancellationToken ct)

--- a/Editor/Connection/AcpClient.cs
+++ b/Editor/Connection/AcpClient.cs
@@ -2,12 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using DotCraft.Editor.Extensions;
 using DotCraft.Editor.Protocol;
 using DotCraft.Editor.Settings;
+using Newtonsoft.Json.Linq;
 using UnityEngine;
 
 namespace DotCraft.Editor.Connection
@@ -25,12 +25,6 @@ namespace DotCraft.Editor.Connection
         private string _sessionId;
         private bool _isConnected;
         private bool _isRunning;
-
-        private static readonly JsonSerializerOptions JsonOptions = new()
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            PropertyNameCaseInsensitive = true
-        };
 
         /// <summary>
         /// Current session ID.
@@ -400,7 +394,7 @@ namespace DotCraft.Editor.Connection
                     ct
                 );
 
-                var typed = result.Deserialize<SessionSetConfigOptionResult>(JsonOptions);
+                var typed = DotCraftJson.ToObject<SessionSetConfigOptionResult>(result);
                 if (typed?.ConfigOptions != null)
                 {
                     ConfigOptions = typed.ConfigOptions;
@@ -430,7 +424,7 @@ namespace DotCraft.Editor.Connection
                     ct
                 );
 
-                var typed = result.Deserialize<SessionListResult>(JsonOptions);
+                var typed = DotCraftJson.ToObject<SessionListResult>(result);
                 return typed?.Sessions;
             }
             catch
@@ -455,7 +449,7 @@ namespace DotCraft.Editor.Connection
                     ct
                 );
 
-                _ = result.Deserialize<SessionDeleteResult>(JsonOptions);
+                _ = DotCraftJson.ToObject<SessionDeleteResult>(result);
                 return true;
             }
             catch
@@ -469,7 +463,7 @@ namespace DotCraft.Editor.Connection
             // Permission request handler
             _transport.RegisterHandler(AcpMethods.RequestPermission, async (paramsJson) =>
             {
-                var @params = paramsJson.Deserialize<RequestPermissionParams>(JsonOptions);
+                var @params = DotCraftJson.ToObject<RequestPermissionParams>(paramsJson);
                 var tcs = new TaskCompletionSource<RequestPermissionResult>();
 
                 OnPermissionRequest?.Invoke(@params, result => tcs.TrySetResult(result));
@@ -480,44 +474,44 @@ namespace DotCraft.Editor.Connection
             // File handlers
             _transport.RegisterHandler(AcpMethods.FsReadTextFile, async (paramsJson) =>
             {
-                var @params = paramsJson.Deserialize<FsReadTextFileParams>(JsonOptions);
+                var @params = DotCraftJson.ToObject<FsReadTextFileParams>(paramsJson);
                 return await HandleReadTextFileAsync(@params);
             });
 
             _transport.RegisterHandler(AcpMethods.FsWriteTextFile, async (paramsJson) =>
             {
-                var @params = paramsJson.Deserialize<FsWriteTextFileParams>(JsonOptions);
+                var @params = DotCraftJson.ToObject<FsWriteTextFileParams>(paramsJson);
                 return await HandleWriteTextFileAsync(@params);
             });
 
             // Terminal handlers
             _transport.RegisterHandler(AcpMethods.TerminalCreate, async (paramsJson) =>
             {
-                var @params = paramsJson.Deserialize<TerminalCreateParams>(JsonOptions);
+                var @params = DotCraftJson.ToObject<TerminalCreateParams>(paramsJson);
                 return await HandleTerminalCreateAsync(@params);
             });
 
             _transport.RegisterHandler(AcpMethods.TerminalGetOutput, async (paramsJson) =>
             {
-                var @params = paramsJson.Deserialize<TerminalGetOutputParams>(JsonOptions);
+                var @params = DotCraftJson.ToObject<TerminalGetOutputParams>(paramsJson);
                 return await HandleTerminalGetOutputAsync(@params);
             });
 
             _transport.RegisterHandler(AcpMethods.TerminalWaitForExit, async (paramsJson) =>
             {
-                var @params = paramsJson.Deserialize<TerminalWaitForExitParams>(JsonOptions);
+                var @params = DotCraftJson.ToObject<TerminalWaitForExitParams>(paramsJson);
                 return await HandleTerminalWaitForExitAsync(@params);
             });
 
             _transport.RegisterHandler(AcpMethods.TerminalKill, async (paramsJson) =>
             {
-                var @params = paramsJson.Deserialize<TerminalKillParams>(JsonOptions);
+                var @params = DotCraftJson.ToObject<TerminalKillParams>(paramsJson);
                 return await HandleTerminalKillAsync(@params);
             });
 
             _transport.RegisterHandler(AcpMethods.TerminalRelease, async (paramsJson) =>
             {
-                var @params = paramsJson.Deserialize<TerminalReleaseParams>(JsonOptions);
+                var @params = DotCraftJson.ToObject<TerminalReleaseParams>(paramsJson);
                 return await HandleTerminalReleaseAsync(@params);
             });
 
@@ -561,7 +555,7 @@ namespace DotCraft.Editor.Connection
             };
 
             var result = await _transport.SendRequestAsync(AcpMethods.Initialize, @params, ct);
-            return result.Deserialize<InitializeResult>(JsonOptions);
+            return DotCraftJson.ToObject<InitializeResult>(result);
         }
 
         private static List<AcpRuntimeToolDescriptor> BuildBuiltinUnityRuntimeTools()
@@ -665,7 +659,7 @@ namespace DotCraft.Editor.Connection
             };
 
             var result = await _transport.SendRequestAsync(AcpMethods.SessionNew, @params, ct);
-            return result.Deserialize<SessionNewResult>(JsonOptions);
+            return DotCraftJson.ToObject<SessionNewResult>(result);
         }
 
         private async Task<SessionLoadResult> LoadSessionAsync(string sessionId, CancellationToken ct)
@@ -678,7 +672,7 @@ namespace DotCraft.Editor.Connection
             };
 
             var result = await _transport.SendRequestAsync(AcpMethods.SessionLoad, @params, ct);
-            return result.Deserialize<SessionLoadResult>(JsonOptions);
+            return DotCraftJson.ToObject<SessionLoadResult>(result);
         }
 
         /// <summary>
@@ -754,9 +748,9 @@ namespace DotCraft.Editor.Connection
             }
         }
 
-        private void HandleSessionUpdate(JsonElement paramsJson)
+        private void HandleSessionUpdate(JToken paramsJson)
         {
-            var @params = paramsJson.Deserialize<SessionUpdateParams>(JsonOptions);
+            var @params = DotCraftJson.ToObject<SessionUpdateParams>(paramsJson);
             var update = @params?.Update;
             if (update == null) return;
 

--- a/Editor/Connection/AcpTransportClient.cs
+++ b/Editor/Connection/AcpTransportClient.cs
@@ -2,11 +2,12 @@ using System;
 using System.Collections.Concurrent;
 using System.IO;
 using System.Text;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using DotCraft.Editor.Protocol;
 using DotCraft.Editor.Settings;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using UnityEngine;
 
 namespace DotCraft.Editor.Connection
@@ -24,35 +25,29 @@ namespace DotCraft.Editor.Connection
         private bool _isRunning;
 
         // Pending requests awaiting response (Client→Agent)
-        private readonly ConcurrentDictionary<int, TaskCompletionSource<JsonElement>> _pendingRequests = new();
+        private readonly ConcurrentDictionary<int, TaskCompletionSource<JToken>> _pendingRequests = new();
 
         // Incoming Agent→Client requests queue
         private readonly SemaphoreSlim _incomingSemaphore = new(0);
 
         // Request handlers
-        private readonly ConcurrentDictionary<string, Func<JsonElement, Task<object>>> _requestHandlers = new();
+        private readonly ConcurrentDictionary<string, Func<JToken, Task<object>>> _requestHandlers = new();
 
         // Extension method handlers keyed by prefix (e.g. "_unity/")
-        private readonly ConcurrentDictionary<string, Func<string, JsonElement, Task<object>>> _extensionHandlers = new();
+        private readonly ConcurrentDictionary<string, Func<string, JToken, Task<object>>> _extensionHandlers = new();
 
         private Task _readerLoopTask;
         private CancellationTokenSource _readerCts;
 
-        private static readonly JsonSerializerOptions JsonOptions = new()
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
-        };
-
         /// <summary>
         /// Event raised when a session/update notification is received.
         /// </summary>
-        public event Action<JsonElement> OnSessionUpdate;
+        public event Action<JToken> OnSessionUpdate;
 
         /// <summary>
         /// Event raised when any notification is received.
         /// </summary>
-        public event Action<string, JsonElement> OnNotification;
+        public event Action<string, JToken> OnNotification;
 
         /// <summary>
         /// Event raised when transport encounters an error.
@@ -129,7 +124,7 @@ namespace DotCraft.Editor.Connection
         /// <summary>
         /// Registers a handler for Agent→Client requests.
         /// </summary>
-        public void RegisterHandler(string method, Func<JsonElement, Task<object>> handler)
+        public void RegisterHandler(string method, Func<JToken, Task<object>> handler)
         {
             _requestHandlers[method] = handler;
         }
@@ -138,7 +133,7 @@ namespace DotCraft.Editor.Connection
         /// Registers a handler for extension methods matching the given prefix (e.g. "_unity/").
         /// The method name is passed as a separate parameter instead of being injected into params.
         /// </summary>
-        public void RegisterExtensionHandler(string prefix, Func<string, JsonElement, Task<object>> handler)
+        public void RegisterExtensionHandler(string prefix, Func<string, JToken, Task<object>> handler)
         {
             _extensionHandlers[prefix] = handler;
         }
@@ -154,13 +149,13 @@ namespace DotCraft.Editor.Connection
         /// <summary>
         /// Sends a request to the Agent and awaits the response.
         /// </summary>
-        public async Task<JsonElement> SendRequestAsync(string method, object @params, CancellationToken ct = default, TimeSpan? timeout = null)
+        public async Task<JToken> SendRequestAsync(string method, object @params, CancellationToken ct = default, TimeSpan? timeout = null)
         {
             if (_writer == null)
                 throw new InvalidOperationException("Transport not initialized.");
 
             var id = Interlocked.Increment(ref _nextOutgoingId);
-            var tcs = new TaskCompletionSource<JsonElement>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource<JToken>(TaskCreationOptions.RunContinuationsAsynchronously);
             _pendingRequests[id] = tcs;
 
             try
@@ -202,7 +197,7 @@ namespace DotCraft.Editor.Connection
         /// <summary>
         /// Sends a response to an Agent→Client request.
         /// </summary>
-        public void SendResponse(JsonElement? id, object result)
+        public void SendResponse(JToken id, object result)
         {
             if (_writer == null) return;
 
@@ -213,7 +208,7 @@ namespace DotCraft.Editor.Connection
         /// <summary>
         /// Sends an error response to an Agent→Client request.
         /// </summary>
-        public void SendError(JsonElement? id, int code, string message, object data = null)
+        public void SendError(JToken id, int code, string message, object data = null)
         {
             if (_writer == null) return;
 
@@ -261,12 +256,12 @@ namespace DotCraft.Editor.Connection
             }
         }
 
-        private void ProcessMessage(string line)
+        internal void ProcessMessage(string line)
         {
-            JsonElement root;
+            JObject root;
             try
             {
-                root = JsonSerializer.Deserialize<JsonElement>(line, JsonOptions);
+                root = JObject.Parse(line);
             }
             catch (JsonException)
             {
@@ -279,36 +274,39 @@ namespace DotCraft.Editor.Connection
             }
 
             // Check if this is a response to one of our requests
-            if (root.TryGetProperty("id", out var idProp) &&
-                !root.TryGetProperty("method", out _) &&
-                idProp.ValueKind == JsonValueKind.Number)
+            var idProp = root["id"];
+            if (idProp != null &&
+                root["method"] == null &&
+                idProp.Type == JTokenType.Integer)
             {
-                var id = idProp.GetInt32();
+                var id = idProp.ToObject<int>();
                 if (_pendingRequests.TryRemove(id, out var tcs))
                 {
-                    if (root.TryGetProperty("result", out var resultProp))
+                    var resultProp = root["result"];
+                    var errorProp = root["error"];
+                    if (resultProp != null)
                     {
                         tcs.TrySetResult(resultProp);
                     }
-                    else if (root.TryGetProperty("error", out var errorProp))
+                    else if (errorProp != null)
                     {
-                        tcs.TrySetException(new AcpTransportException(errorProp.ToString()));
+                        tcs.TrySetException(new AcpTransportException(errorProp.ToString(Formatting.None)));
                     }
                     else
                     {
-                        tcs.TrySetResult(default);
+                        tcs.TrySetResult(null);
                     }
                 }
                 return;
             }
 
             // Check if this is a request from the Agent
-            if (root.TryGetProperty("method", out var methodProp))
+            var methodProp = root["method"];
+            if (methodProp != null)
             {
-                var method = methodProp.GetString();
-                var id = root.TryGetProperty("id", out idProp) ? idProp : (JsonElement?)null;
-                var hasParams = root.TryGetProperty("params", out var paramsProp);
-                var @params = hasParams ? paramsProp : (JsonElement?)null;
+                var method = methodProp.ToObject<string>();
+                var id = root["id"];
+                var @params = root["params"];
 
                 // Check if it's a notification (no id)
                 if (id == null)
@@ -318,34 +316,34 @@ namespace DotCraft.Editor.Connection
                 else
                 {
                     // It's a request - need to respond
-                    HandleRequestAsync(method, @params, id.Value).Forget();
+                    HandleRequestAsync(method, @params, id).Forget();
                 }
             }
         }
 
-        private void HandleNotification(string method, JsonElement? @params)
+        private void HandleNotification(string method, JToken @params)
         {
-            if (method == AcpMethods.SessionUpdate && @params.HasValue)
+            if (method == AcpMethods.SessionUpdate && @params != null)
             {
-                OnSessionUpdate?.Invoke(@params.Value);
+                OnSessionUpdate?.Invoke(@params);
             }
 
-            OnNotification?.Invoke(method, @params ?? default);
+            OnNotification?.Invoke(method, @params);
         }
 
-        private async Task HandleRequestAsync(string method, JsonElement? @params, JsonElement id)
+        private async Task HandleRequestAsync(string method, JToken @params, JToken id)
         {
             try
             {
                 if (_requestHandlers.TryGetValue(method, out var handler))
                 {
-                    var result = await handler(@params ?? default);
+                    var result = await handler(ParamsOrEmptyObject(@params));
                     SendResponse(id, result);
                 }
                 else if (TryGetExtensionHandler(method, out var extHandler))
                 {
                     // Extension method handling - pass method name separately
-                    var result = await extHandler(method, @params ?? default);
+                    var result = await extHandler(method, ParamsOrEmptyObject(@params));
                     SendResponse(id, result);
                 }
                 else
@@ -359,7 +357,16 @@ namespace DotCraft.Editor.Connection
             }
         }
 
-        private bool TryGetExtensionHandler(string method, out Func<string, JsonElement, Task<object>> handler)
+        private static JToken ParamsOrEmptyObject(JToken parameters)
+        {
+            return parameters == null
+                   || parameters.Type == JTokenType.Null
+                   || parameters.Type == JTokenType.Undefined
+                ? new JObject()
+                : parameters;
+        }
+
+        private bool TryGetExtensionHandler(string method, out Func<string, JToken, Task<object>> handler)
         {
             foreach (var kvp in _extensionHandlers)
             {
@@ -376,7 +383,7 @@ namespace DotCraft.Editor.Connection
 
         private void WriteLine(object message)
         {
-            var json = JsonSerializer.Serialize(message, JsonOptions);
+            var json = DotCraftJson.Serialize(message);
 
             if (DotCraftSettings.Instance.VerboseLogging)
             {

--- a/Editor/Connection/DotCraftHubClient.cs
+++ b/Editor/Connection/DotCraftHubClient.cs
@@ -4,10 +4,9 @@ using System.Diagnostics;
 using System.IO;
 using System.Net.Http;
 using System.Text;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using DotCraft.Editor.Protocol;
 using DotCraft.Editor.Settings;
 using Debug = UnityEngine.Debug;
 
@@ -22,13 +21,6 @@ namespace DotCraft.Editor.Connection
         private const int StartupTimeoutMs = 15000;
         private const int PollIntervalMs = 200;
         private static readonly HttpClient Http = new();
-        private static readonly JsonSerializerOptions JsonOptions = new()
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            PropertyNameCaseInsensitive = true,
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-        };
-
         /// <summary>
         /// Ensures a Hub-managed AppServer exists for the workspace and returns its WebSocket endpoint.
         /// </summary>
@@ -105,7 +97,7 @@ namespace DotCraft.Editor.Connection
             try
             {
                 var json = File.ReadAllText(lockPath);
-                var info = JsonSerializer.Deserialize<HubLockInfo>(json, JsonOptions);
+                var info = DotCraftJson.Deserialize<HubLockInfo>(json);
                 if (info == null
                     || info.Pid <= 0
                     || string.IsNullOrWhiteSpace(info.ApiBaseUrl)
@@ -159,7 +151,7 @@ namespace DotCraft.Editor.Connection
             string workspacePath,
             CancellationToken ct)
         {
-            var body = JsonSerializer.Serialize(new
+            var body = DotCraftJson.Serialize(new
             {
                 workspacePath,
                 client = new
@@ -168,7 +160,7 @@ namespace DotCraft.Editor.Connection
                     version = "0.1.0"
                 },
                 startIfMissing = true
-            }, JsonOptions);
+            });
 
             using var request = new HttpRequestMessage(HttpMethod.Post, $"{hub.ApiBaseUrl}/v1/appservers/ensure");
             request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", hub.Token);
@@ -179,7 +171,7 @@ namespace DotCraft.Editor.Connection
             if (!response.IsSuccessStatusCode)
                 throw CreateHubException(response, text);
 
-            return JsonSerializer.Deserialize<HubAppServerResponse>(text, JsonOptions)
+            return DotCraftJson.Deserialize<HubAppServerResponse>(text)
                    ?? throw new InvalidOperationException("Hub returned an empty AppServer response.");
         }
 
@@ -187,7 +179,7 @@ namespace DotCraft.Editor.Connection
         {
             try
             {
-                var error = JsonSerializer.Deserialize<HubErrorResponse>(body, JsonOptions);
+                var error = DotCraftJson.Deserialize<HubErrorResponse>(body);
                 if (error?.Error != null
                     && (!string.IsNullOrWhiteSpace(error.Error.Code) || !string.IsNullOrWhiteSpace(error.Error.Message)))
                 {

--- a/Editor/Extensions/ExtensionMethodRouter.cs
+++ b/Editor/Extensions/ExtensionMethodRouter.cs
@@ -3,8 +3,8 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text.Json;
 using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEngine;
 
@@ -18,7 +18,7 @@ namespace DotCraft.Editor.Extensions
     /// </summary>
     public sealed class ExtensionMethodRouter
     {
-        private readonly ConcurrentDictionary<string, Func<JsonElement, Task<object>>> _handlers = new();
+        private readonly ConcurrentDictionary<string, Func<JToken, Task<object>>> _handlers = new();
 
         public ExtensionMethodRouter()
         {
@@ -28,7 +28,7 @@ namespace DotCraft.Editor.Extensions
         /// <summary>
         /// Registers a handler for an extension method.
         /// </summary>
-        public void RegisterHandler(string method, Func<JsonElement, Task<object>> handler)
+        public void RegisterHandler(string method, Func<JToken, Task<object>> handler)
         {
             _handlers[method] = handler;
         }
@@ -36,7 +36,7 @@ namespace DotCraft.Editor.Extensions
         /// <summary>
         /// Registers a synchronous handler for an extension method.
         /// </summary>
-        public void RegisterHandler(string method, Func<JsonElement, object> handler)
+        public void RegisterHandler(string method, Func<JToken, object> handler)
         {
             _handlers[method] = paramsJson => Task.FromResult(handler(paramsJson));
         }
@@ -44,7 +44,7 @@ namespace DotCraft.Editor.Extensions
         /// <summary>
         /// Handles an extension method request.
         /// </summary>
-        public async Task<object> HandleAsync(string method, JsonElement paramsJson)
+        public async Task<object> HandleAsync(string method, JToken paramsJson)
         {
             if (!_handlers.TryGetValue(method, out var handler))
             {
@@ -92,11 +92,11 @@ namespace DotCraft.Editor.Extensions
         /// <summary>
         /// Queries the Unity scene hierarchy and returns GameObject information.
         /// </summary>
-        public static Task<object> HandleSceneQuery(JsonElement paramsJson)
+        public static Task<object> HandleSceneQuery(JToken paramsJson)
         {
-            var query = paramsJson.TryGetProperty("query", out var q) ? q.GetString() : null;
-            var includeComponents = paramsJson.TryGetProperty("includeComponents", out var ic) && ic.GetBoolean();
-            var maxDepth = paramsJson.TryGetProperty("maxDepth", out var md) ? md.GetInt32() : 10;
+            var query = paramsJson?["query"]?.ToObject<string>();
+            var includeComponents = paramsJson?["includeComponents"]?.ToObject<bool>() ?? false;
+            var maxDepth = paramsJson?["maxDepth"]?.ToObject<int>() ?? 10;
 
             var results = new List<object>();
 
@@ -193,7 +193,7 @@ namespace DotCraft.Editor.Extensions
         /// <summary>
         /// Gets the currently selected objects in the Unity Editor.
         /// </summary>
-        public static Task<object> HandleGetSelection(JsonElement _)
+        public static Task<object> HandleGetSelection(JToken _)
         {
             var selected = Selection.gameObjects;
             var results = new List<GameObjectInfo>();
@@ -306,13 +306,11 @@ namespace DotCraft.Editor.Extensions
         /// <summary>
         /// Gets recent Unity console log entries.
         /// </summary>
-        public static Task<object> HandleGetConsoleLogs(JsonElement paramsJson)
+        public static Task<object> HandleGetConsoleLogs(JToken paramsJson)
         {
-            var types = paramsJson.TryGetProperty("types", out var t)
-                ? t.Deserialize<string[]>(new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
-                : null;
+            var types = paramsJson?["types"]?.ToObject<string[]>();
 
-            var limit = paramsJson.TryGetProperty("limit", out var l) ? l.GetInt32() : 50;
+            var limit = paramsJson?["limit"]?.ToObject<int>() ?? 50;
 
             var logs = UnityConsoleLogCollector.GetLogs(types, limit);
 
@@ -332,7 +330,7 @@ namespace DotCraft.Editor.Extensions
         /// <summary>
         /// Gets Unity project information including version and installed packages.
         /// </summary>
-        public static Task<object> HandleGetProjectInfo(JsonElement _)
+        public static Task<object> HandleGetProjectInfo(JToken _)
         {
             var info = new
             {
@@ -360,11 +358,11 @@ namespace DotCraft.Editor.Extensions
                 if (File.Exists(manifestPath))
                 {
                     var json = File.ReadAllText(manifestPath);
-                    var doc = JsonDocument.Parse(json);
+                    var doc = JObject.Parse(json);
 
-                    if (doc.RootElement.TryGetProperty("dependencies", out var deps))
+                    if (doc["dependencies"] is JObject deps)
                     {
-                        foreach (var prop in deps.EnumerateObject())
+                        foreach (var prop in deps.Properties())
                         {
                             packages.Add(prop.Name);
                         }

--- a/Editor/Protocol/AcpProtocolTypes.cs
+++ b/Editor/Protocol/AcpProtocolTypes.cs
@@ -50,6 +50,76 @@ namespace DotCraft.Editor.Protocol
         [JsonPropertyName("extensions")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string[] Extensions { get; set; }
+
+        [JsonPropertyName("_meta")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public ClientCapabilitiesMeta Meta { get; set; }
+    }
+
+    public sealed class ClientCapabilitiesMeta
+    {
+        [JsonPropertyName("dotcraft")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public DotCraftClientCapabilities DotCraft { get; set; }
+    }
+
+    public sealed class DotCraftClientCapabilities
+    {
+        /// <summary>
+        /// Runtime tools implemented by this ACP client and exposed through DotCraft dynamic tools.
+        /// </summary>
+        [JsonPropertyName("runtimeTools")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<AcpRuntimeToolDescriptor> RuntimeTools { get; set; }
+    }
+
+    public sealed class AcpRuntimeToolDescriptor
+    {
+        [JsonPropertyName("namespace")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string Namespace { get; set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = "";
+
+        [JsonPropertyName("description")]
+        public string Description { get; set; } = "";
+
+        [JsonPropertyName("inputSchema")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public object InputSchema { get; set; }
+
+        [JsonPropertyName("acpMethod")]
+        public string AcpMethod { get; set; } = "";
+
+        [JsonPropertyName("kind")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string Kind { get; set; }
+
+        [JsonPropertyName("deferLoading")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public bool? DeferLoading { get; set; }
+
+        [JsonPropertyName("approval")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public AcpRuntimeToolApprovalDescriptor Approval { get; set; }
+    }
+
+    public sealed class AcpRuntimeToolApprovalDescriptor
+    {
+        [JsonPropertyName("kind")]
+        public string Kind { get; set; } = "";
+
+        [JsonPropertyName("targetArgument")]
+        public string TargetArgument { get; set; } = "";
+
+        [JsonPropertyName("operation")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string Operation { get; set; }
+
+        [JsonPropertyName("operationArgument")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string OperationArgument { get; set; }
     }
 
     public sealed class FsCapabilities

--- a/Editor/Protocol/AcpProtocolTypes.cs
+++ b/Editor/Protocol/AcpProtocolTypes.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
-using System.Text.Json;
-using System.Text.Json.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace DotCraft.Editor.Protocol
 {
@@ -11,35 +11,35 @@ namespace DotCraft.Editor.Protocol
     /// </summary>
     public sealed class InitializeParams
     {
-        [JsonPropertyName("protocolVersion")]
+        [JsonProperty("protocolVersion")]
         public int ProtocolVersion { get; set; }
 
-        [JsonPropertyName("clientCapabilities")]
+        [JsonProperty("clientCapabilities")]
         public ClientCapabilities ClientCapabilities { get; set; }
 
-        [JsonPropertyName("clientInfo")]
+        [JsonProperty("clientInfo")]
         public ClientInfo ClientInfo { get; set; }
     }
 
     public sealed class ClientInfo
     {
-        [JsonPropertyName("name")]
+        [JsonProperty("name")]
         public string Name { get; set; } = "";
 
-        [JsonPropertyName("title")]
+        [JsonProperty("title")]
         public string Title { get; set; }
 
-        [JsonPropertyName("version")]
+        [JsonProperty("version")]
         public string Version { get; set; }
     }
 
     public sealed class ClientCapabilities
     {
-        [JsonPropertyName("fs")]
+        [JsonProperty("fs")]
         [JsonConverter(typeof(BoolOrObjectConverter<FsCapabilities>))]
         public FsCapabilities Fs { get; set; }
 
-        [JsonPropertyName("terminal")]
+        [JsonProperty("terminal")]
         [JsonConverter(typeof(BoolOrObjectConverter<TerminalCapabilities>))]
         public TerminalCapabilities Terminal { get; set; }
 
@@ -47,19 +47,16 @@ namespace DotCraft.Editor.Protocol
         /// Extension method prefixes supported by this client (e.g. ["_unity"]).
         /// The agent uses this list to decide which extension tool families to register.
         /// </summary>
-        [JsonPropertyName("extensions")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("extensions", NullValueHandling = NullValueHandling.Ignore)]
         public string[] Extensions { get; set; }
 
-        [JsonPropertyName("_meta")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("_meta", NullValueHandling = NullValueHandling.Ignore)]
         public ClientCapabilitiesMeta Meta { get; set; }
     }
 
     public sealed class ClientCapabilitiesMeta
     {
-        [JsonPropertyName("dotcraft")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("dotcraft", NullValueHandling = NullValueHandling.Ignore)]
         public DotCraftClientCapabilities DotCraft { get; set; }
     }
 
@@ -68,66 +65,58 @@ namespace DotCraft.Editor.Protocol
         /// <summary>
         /// Runtime tools implemented by this ACP client and exposed through DotCraft dynamic tools.
         /// </summary>
-        [JsonPropertyName("runtimeTools")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("runtimeTools", NullValueHandling = NullValueHandling.Ignore)]
         public List<AcpRuntimeToolDescriptor> RuntimeTools { get; set; }
     }
 
     public sealed class AcpRuntimeToolDescriptor
     {
-        [JsonPropertyName("namespace")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("namespace", NullValueHandling = NullValueHandling.Ignore)]
         public string Namespace { get; set; }
 
-        [JsonPropertyName("name")]
+        [JsonProperty("name")]
         public string Name { get; set; } = "";
 
-        [JsonPropertyName("description")]
+        [JsonProperty("description")]
         public string Description { get; set; } = "";
 
-        [JsonPropertyName("inputSchema")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("inputSchema", NullValueHandling = NullValueHandling.Ignore)]
         public object InputSchema { get; set; }
 
-        [JsonPropertyName("acpMethod")]
+        [JsonProperty("acpMethod")]
         public string AcpMethod { get; set; } = "";
 
-        [JsonPropertyName("kind")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("kind", NullValueHandling = NullValueHandling.Ignore)]
         public string Kind { get; set; }
 
-        [JsonPropertyName("deferLoading")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("deferLoading", NullValueHandling = NullValueHandling.Ignore)]
         public bool? DeferLoading { get; set; }
 
-        [JsonPropertyName("approval")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("approval", NullValueHandling = NullValueHandling.Ignore)]
         public AcpRuntimeToolApprovalDescriptor Approval { get; set; }
     }
 
     public sealed class AcpRuntimeToolApprovalDescriptor
     {
-        [JsonPropertyName("kind")]
+        [JsonProperty("kind")]
         public string Kind { get; set; } = "";
 
-        [JsonPropertyName("targetArgument")]
+        [JsonProperty("targetArgument")]
         public string TargetArgument { get; set; } = "";
 
-        [JsonPropertyName("operation")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("operation", NullValueHandling = NullValueHandling.Ignore)]
         public string Operation { get; set; }
 
-        [JsonPropertyName("operationArgument")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("operationArgument", NullValueHandling = NullValueHandling.Ignore)]
         public string OperationArgument { get; set; }
     }
 
     public sealed class FsCapabilities
     {
-        [JsonPropertyName("readTextFile")]
+        [JsonProperty("readTextFile")]
         public bool ReadTextFile { get; set; }
 
-        [JsonPropertyName("writeTextFile")]
+        [JsonProperty("writeTextFile")]
         public bool WriteTextFile { get; set; }
 
         public static FsCapabilities All => new() { ReadTextFile = true, WriteTextFile = true };
@@ -135,7 +124,7 @@ namespace DotCraft.Editor.Protocol
 
     public sealed class TerminalCapabilities
     {
-        [JsonPropertyName("create")]
+        [JsonProperty("create")]
         public bool Create { get; set; }
 
         public static TerminalCapabilities All => new() { Create = true };
@@ -146,41 +135,48 @@ namespace DotCraft.Editor.Protocol
     /// </summary>
     public sealed class BoolOrObjectConverter<T> : JsonConverter<T> where T : class
     {
-        public override T Read(ref Utf8JsonReader reader, System.Type typeToConvert, JsonSerializerOptions options)
+        public override T ReadJson(
+            JsonReader reader,
+            System.Type objectType,
+            T existingValue,
+            bool hasExistingValue,
+            JsonSerializer serializer)
         {
-            if (reader.TokenType == JsonTokenType.True)
+            if (reader.TokenType == JsonToken.Boolean)
             {
-                var allProp = typeToConvert.GetProperty("All",
+                if (reader.Value is bool enabled && !enabled)
+                    return null;
+
+                var allProp = objectType.GetProperty("All",
                     System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
                 return allProp?.GetValue(null) as T
                        ?? System.Activator.CreateInstance<T>();
             }
 
-            if (reader.TokenType == JsonTokenType.False || reader.TokenType == JsonTokenType.Null)
+            if (reader.TokenType == JsonToken.Null || reader.TokenType == JsonToken.Undefined)
                 return null;
 
-            return JsonSerializer.Deserialize<T>(ref reader, options);
+            return JToken.Load(reader).ToObject<T>(serializer);
         }
 
-        public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+        public override void WriteJson(JsonWriter writer, T value, JsonSerializer serializer)
         {
-            JsonSerializer.Serialize(writer, value, options);
+            serializer.Serialize(writer, value);
         }
     }
 
     public sealed class InitializeResult
     {
-        [JsonPropertyName("protocolVersion")]
+        [JsonProperty("protocolVersion")]
         public int ProtocolVersion { get; set; }
 
-        [JsonPropertyName("agentCapabilities")]
+        [JsonProperty("agentCapabilities")]
         public AgentCapabilities AgentCapabilities { get; set; } = new();
 
-        [JsonPropertyName("agentInfo")]
+        [JsonProperty("agentInfo")]
         public AgentInfo AgentInfo { get; set; } = new();
 
-        [JsonPropertyName("authMethods")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("authMethods", NullValueHandling = NullValueHandling.Ignore)]
         public AuthMethod[] AuthMethods { get; set; }
     }
 
@@ -190,82 +186,79 @@ namespace DotCraft.Editor.Protocol
 
     public sealed class AuthMethod
     {
-        [JsonPropertyName("id")]
+        [JsonProperty("id")]
         public string Id { get; set; } = "";
 
-        [JsonPropertyName("name")]
+        [JsonProperty("name")]
         public string Name { get; set; } = "";
 
-        [JsonPropertyName("description")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("description", NullValueHandling = NullValueHandling.Ignore)]
         public string Description { get; set; }
     }
 
     public sealed class AuthenticateParams
     {
-        [JsonPropertyName("methodId")]
+        [JsonProperty("methodId")]
         public string MethodId { get; set; } = "";
     }
 
     public sealed class AuthenticateResult
     {
-        [JsonPropertyName("success")]
+        [JsonProperty("success")]
         public bool Success { get; set; }
     }
 
     public sealed class AgentCapabilities
     {
-        [JsonPropertyName("loadSession")]
+        [JsonProperty("loadSession")]
         public bool LoadSession { get; set; }
 
-        [JsonPropertyName("listSessions")]
+        [JsonProperty("listSessions")]
         public bool ListSessions { get; set; }
 
-        [JsonPropertyName("promptCapabilities")]
+        [JsonProperty("promptCapabilities")]
         public PromptCapabilities PromptCapabilities { get; set; }
 
-        [JsonPropertyName("_meta")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("_meta", NullValueHandling = NullValueHandling.Ignore)]
         public AgentCapabilitiesMeta Meta { get; set; }
     }
 
     public sealed class AgentCapabilitiesMeta
     {
-        [JsonPropertyName("dotcraft")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("dotcraft", NullValueHandling = NullValueHandling.Ignore)]
         public DotCraftAgentCapabilities DotCraft { get; set; }
     }
 
     public sealed class DotCraftAgentCapabilities
     {
-        [JsonPropertyName("sessionDelete")]
+        [JsonProperty("sessionDelete")]
         public bool SessionDelete { get; set; }
     }
 
     public sealed class PromptCapabilities
     {
-        [JsonPropertyName("text")]
+        [JsonProperty("text")]
         public bool Text { get; set; } = true;
 
-        [JsonPropertyName("image")]
+        [JsonProperty("image")]
         public bool Image { get; set; }
 
-        [JsonPropertyName("audio")]
+        [JsonProperty("audio")]
         public bool Audio { get; set; }
 
-        [JsonPropertyName("embeddedContext")]
+        [JsonProperty("embeddedContext")]
         public bool EmbeddedContext { get; set; }
     }
 
     public sealed class AgentInfo
     {
-        [JsonPropertyName("name")]
+        [JsonProperty("name")]
         public string Name { get; set; } = "";
 
-        [JsonPropertyName("title")]
+        [JsonProperty("title")]
         public string Title { get; set; }
 
-        [JsonPropertyName("version")]
+        [JsonProperty("version")]
         public string Version { get; set; }
     }
 
@@ -276,69 +269,62 @@ namespace DotCraft.Editor.Protocol
     /// <summary>ACP spec: env entry for MCP server (array of name/value).</summary>
     public sealed class AcpEnvVariable
     {
-        [JsonPropertyName("name")]
+        [JsonProperty("name")]
         public string Name { get; set; } = "";
 
-        [JsonPropertyName("value")]
+        [JsonProperty("value")]
         public string Value { get; set; } = "";
     }
 
     /// <summary>ACP spec: HTTP header for MCP server (array of name/value).</summary>
     public sealed class AcpHttpHeader
     {
-        [JsonPropertyName("name")]
+        [JsonProperty("name")]
         public string Name { get; set; } = "";
 
-        [JsonPropertyName("value")]
+        [JsonProperty("value")]
         public string Value { get; set; } = "";
     }
 
     public sealed class SessionNewParams
     {
-        [JsonPropertyName("cwd")]
+        [JsonProperty("cwd")]
         public string Cwd { get; set; }
 
-        [JsonPropertyName("mcpServers")]
+        [JsonProperty("mcpServers")]
         public List<AcpMcpServer> McpServers { get; set; }
     }
 
     public sealed class AcpMcpServer
     {
-        [JsonPropertyName("type")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("type", NullValueHandling = NullValueHandling.Ignore)]
         public string Type { get; set; }
 
-        [JsonPropertyName("name")]
+        [JsonProperty("name")]
         public string Name { get; set; } = "";
 
-        [JsonPropertyName("command")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("command", NullValueHandling = NullValueHandling.Ignore)]
         public string Command { get; set; }
 
-        [JsonPropertyName("args")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("args", NullValueHandling = NullValueHandling.Ignore)]
         public List<string> Args { get; set; }
 
-        [JsonPropertyName("env")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("env", NullValueHandling = NullValueHandling.Ignore)]
         public List<AcpEnvVariable> Env { get; set; }
 
-        [JsonPropertyName("url")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("url", NullValueHandling = NullValueHandling.Ignore)]
         public string Url { get; set; }
 
-        [JsonPropertyName("headers")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("headers", NullValueHandling = NullValueHandling.Ignore)]
         public List<AcpHttpHeader> Headers { get; set; }
     }
 
     public sealed class SessionNewResult
     {
-        [JsonPropertyName("sessionId")]
+        [JsonProperty("sessionId")]
         public string SessionId { get; set; } = "";
 
-        [JsonPropertyName("configOptions")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("configOptions", NullValueHandling = NullValueHandling.Ignore)]
         public List<ConfigOption> ConfigOptions { get; set; }
     }
 
@@ -348,23 +334,22 @@ namespace DotCraft.Editor.Protocol
 
     public sealed class SessionLoadParams
     {
-        [JsonPropertyName("sessionId")]
+        [JsonProperty("sessionId")]
         public string SessionId { get; set; } = "";
 
-        [JsonPropertyName("cwd")]
+        [JsonProperty("cwd")]
         public string Cwd { get; set; }
 
-        [JsonPropertyName("mcpServers")]
+        [JsonProperty("mcpServers")]
         public List<AcpMcpServer> McpServers { get; set; }
     }
 
     public sealed class SessionLoadResult
     {
-        [JsonPropertyName("sessionId")]
+        [JsonProperty("sessionId")]
         public string SessionId { get; set; } = "";
 
-        [JsonPropertyName("configOptions")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("configOptions", NullValueHandling = NullValueHandling.Ignore)]
         public List<ConfigOption> ConfigOptions { get; set; }
     }
 
@@ -374,35 +359,34 @@ namespace DotCraft.Editor.Protocol
 
     public sealed class SessionListParams
     {
-        [JsonPropertyName("cwd")]
+        [JsonProperty("cwd")]
         public string Cwd { get; set; }
 
-        [JsonPropertyName("cursor")]
+        [JsonProperty("cursor")]
         public string Cursor { get; set; }
     }
 
     public sealed class SessionListResult
     {
-        [JsonPropertyName("sessions")]
+        [JsonProperty("sessions")]
         public List<SessionListEntry> Sessions { get; set; } = new();
 
-        [JsonPropertyName("nextCursor")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("nextCursor", NullValueHandling = NullValueHandling.Ignore)]
         public string NextCursor { get; set; }
     }
 
     public sealed class SessionListEntry
     {
-        [JsonPropertyName("sessionId")]
+        [JsonProperty("sessionId")]
         public string SessionId { get; set; } = "";
 
-        [JsonPropertyName("title")]
+        [JsonProperty("title")]
         public string Title { get; set; }
 
-        [JsonPropertyName("updatedAt")]
+        [JsonProperty("updatedAt")]
         public string UpdatedAt { get; set; }
 
-        [JsonPropertyName("cwd")]
+        [JsonProperty("cwd")]
         public string Cwd { get; set; }
     }
 
@@ -412,7 +396,7 @@ namespace DotCraft.Editor.Protocol
 
     public sealed class SessionDeleteParams
     {
-        [JsonPropertyName("sessionId")]
+        [JsonProperty("sessionId")]
         public string SessionId { get; set; } = "";
     }
 
@@ -426,55 +410,49 @@ namespace DotCraft.Editor.Protocol
 
     public sealed class SessionPromptParams
     {
-        [JsonPropertyName("sessionId")]
+        [JsonProperty("sessionId")]
         public string SessionId { get; set; } = "";
 
-        [JsonPropertyName("prompt")]
+        [JsonProperty("prompt")]
         public List<AcpContentBlock> Prompt { get; set; } = new();
 
-        [JsonPropertyName("command")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("command", NullValueHandling = NullValueHandling.Ignore)]
         public string Command { get; set; }
     }
 
     public sealed class AcpContentBlock
     {
-        [JsonPropertyName("type")]
+        [JsonProperty("type")]
         public string Type { get; set; } = "text";
 
-        [JsonPropertyName("text")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("text", NullValueHandling = NullValueHandling.Ignore)]
         public string Text { get; set; }
 
-        [JsonPropertyName("data")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("data", NullValueHandling = NullValueHandling.Ignore)]
         public string Data { get; set; }
 
-        [JsonPropertyName("mimeType")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("mimeType", NullValueHandling = NullValueHandling.Ignore)]
         public string MimeType { get; set; }
 
-        [JsonPropertyName("resource")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("resource", NullValueHandling = NullValueHandling.Ignore)]
         public AcpEmbeddedResource Resource { get; set; }
     }
 
     public sealed class AcpEmbeddedResource
     {
-        [JsonPropertyName("uri")]
+        [JsonProperty("uri")]
         public string Uri { get; set; } = "";
 
-        [JsonPropertyName("mimeType")]
+        [JsonProperty("mimeType")]
         public string MimeType { get; set; }
 
-        [JsonPropertyName("text")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("text", NullValueHandling = NullValueHandling.Ignore)]
         public string Text { get; set; }
     }
 
     public sealed class SessionPromptResult
     {
-        [JsonPropertyName("stopReason")]
+        [JsonProperty("stopReason")]
         public string StopReason { get; set; } = "end_turn";
     }
 
@@ -484,70 +462,61 @@ namespace DotCraft.Editor.Protocol
 
     public sealed class SessionUpdateParams
     {
-        [JsonPropertyName("sessionId")]
+        [JsonProperty("sessionId")]
         public string SessionId { get; set; } = "";
 
-        [JsonPropertyName("update")]
+        [JsonProperty("update")]
         public AcpSessionUpdate Update { get; set; } = new();
     }
 
     public sealed class AcpSessionUpdate
     {
-        [JsonPropertyName("sessionUpdate")]
+        [JsonProperty("sessionUpdate")]
         public string SessionUpdate { get; set; } = "";
 
-        [JsonPropertyName("content")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("content", NullValueHandling = NullValueHandling.Ignore)]
         public object Content { get; set; }
 
-        [JsonPropertyName("toolCallId")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("toolCallId", NullValueHandling = NullValueHandling.Ignore)]
         public string ToolCallId { get; set; }
 
-        [JsonPropertyName("title")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("title", NullValueHandling = NullValueHandling.Ignore)]
         public string Title { get; set; }
 
-        [JsonPropertyName("kind")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("kind", NullValueHandling = NullValueHandling.Ignore)]
         public string Kind { get; set; }
 
-        [JsonPropertyName("status")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("status", NullValueHandling = NullValueHandling.Ignore)]
         public string Status { get; set; }
 
-        [JsonPropertyName("fileLocations")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("fileLocations", NullValueHandling = NullValueHandling.Ignore)]
         public List<AcpFileLocation> FileLocations { get; set; }
 
-        [JsonPropertyName("entries")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("entries", NullValueHandling = NullValueHandling.Ignore)]
         public List<AcpPlanEntry> Entries { get; set; }
 
-        [JsonPropertyName("commands")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("commands", NullValueHandling = NullValueHandling.Ignore)]
         public List<AcpSlashCommand> Commands { get; set; }
 
-        [JsonPropertyName("configOptions")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("configOptions", NullValueHandling = NullValueHandling.Ignore)]
         public List<ConfigOption> ConfigOptions { get; set; }
     }
 
     public sealed class AcpFileLocation
     {
-        [JsonPropertyName("uri")]
+        [JsonProperty("uri")]
         public string Uri { get; set; } = "";
     }
 
     public sealed class AcpPlanEntry
     {
-        [JsonPropertyName("content")]
+        [JsonProperty("content")]
         public string Content { get; set; } = "";
 
-        [JsonPropertyName("priority")]
+        [JsonProperty("priority")]
         public string Priority { get; set; } = AcpPlanEntryPriority.Medium;
 
-        [JsonPropertyName("status")]
+        [JsonProperty("status")]
         public string Status { get; set; } = AcpToolStatus.Pending;
     }
 
@@ -557,19 +526,19 @@ namespace DotCraft.Editor.Protocol
 
     public sealed class SessionSetConfigOptionParams
     {
-        [JsonPropertyName("sessionId")]
+        [JsonProperty("sessionId")]
         public string SessionId { get; set; } = "";
 
-        [JsonPropertyName("configId")]
+        [JsonProperty("configId")]
         public string ConfigId { get; set; } = "";
 
-        [JsonPropertyName("value")]
+        [JsonProperty("value")]
         public string Value { get; set; } = "";
     }
 
     public sealed class SessionSetConfigOptionResult
     {
-        [JsonPropertyName("configOptions")]
+        [JsonProperty("configOptions")]
         public List<ConfigOption> ConfigOptions { get; set; } = new();
     }
 
@@ -579,7 +548,7 @@ namespace DotCraft.Editor.Protocol
 
     public sealed class SessionCancelParams
     {
-        [JsonPropertyName("sessionId")]
+        [JsonProperty("sessionId")]
         public string SessionId { get; set; } = "";
     }
 
@@ -589,59 +558,55 @@ namespace DotCraft.Editor.Protocol
 
     public sealed class RequestPermissionParams
     {
-        [JsonPropertyName("sessionId")]
+        [JsonProperty("sessionId")]
         public string SessionId { get; set; } = "";
 
-        [JsonPropertyName("toolCall")]
+        [JsonProperty("toolCall")]
         public AcpToolCallInfo ToolCall { get; set; } = new();
 
-        [JsonPropertyName("options")]
+        [JsonProperty("options")]
         public List<PermissionOption> Options { get; set; } = new();
     }
 
     public sealed class AcpToolCallInfo
     {
-        [JsonPropertyName("toolCallId")]
+        [JsonProperty("toolCallId")]
         public string ToolCallId { get; set; } = "";
 
-        [JsonPropertyName("title")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("title", NullValueHandling = NullValueHandling.Ignore)]
         public string Title { get; set; }
 
-        [JsonPropertyName("kind")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("kind", NullValueHandling = NullValueHandling.Ignore)]
         public string Kind { get; set; }
 
-        [JsonPropertyName("status")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("status", NullValueHandling = NullValueHandling.Ignore)]
         public string Status { get; set; }
     }
 
     public sealed class PermissionOption
     {
-        [JsonPropertyName("optionId")]
+        [JsonProperty("optionId")]
         public string OptionId { get; set; } = "";
 
-        [JsonPropertyName("name")]
+        [JsonProperty("name")]
         public string Name { get; set; } = "";
 
-        [JsonPropertyName("kind")]
+        [JsonProperty("kind")]
         public string Kind { get; set; } = "";
     }
 
     public sealed class RequestPermissionResult
     {
-        [JsonPropertyName("outcome")]
+        [JsonProperty("outcome")]
         public PermissionOutcome Outcome { get; set; } = new();
     }
 
     public sealed class PermissionOutcome
     {
-        [JsonPropertyName("outcome")]
+        [JsonProperty("outcome")]
         public string Outcome { get; set; } = "";
 
-        [JsonPropertyName("optionId")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("optionId", NullValueHandling = NullValueHandling.Ignore)]
         public string OptionId { get; set; }
     }
 
@@ -651,21 +616,19 @@ namespace DotCraft.Editor.Protocol
 
     public sealed class FsReadTextFileParams
     {
-        [JsonPropertyName("path")]
+        [JsonProperty("path")]
         public string Path { get; set; } = "";
 
-        [JsonPropertyName("offset")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("offset", NullValueHandling = NullValueHandling.Ignore)]
         public int? Offset { get; set; }
 
-        [JsonPropertyName("limit")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("limit", NullValueHandling = NullValueHandling.Ignore)]
         public int? Limit { get; set; }
     }
 
     public sealed class FsReadTextFileResult
     {
-        [JsonPropertyName("content")]
+        [JsonProperty("content")]
         public string Content { get; set; } = "";
     }
 
@@ -675,16 +638,16 @@ namespace DotCraft.Editor.Protocol
 
     public sealed class FsWriteTextFileParams
     {
-        [JsonPropertyName("path")]
+        [JsonProperty("path")]
         public string Path { get; set; } = "";
 
-        [JsonPropertyName("content")]
+        [JsonProperty("content")]
         public string Content { get; set; } = "";
     }
 
     public sealed class FsWriteTextFileResult
     {
-        [JsonPropertyName("success")]
+        [JsonProperty("success")]
         public bool Success { get; set; }
     }
 
@@ -694,59 +657,55 @@ namespace DotCraft.Editor.Protocol
 
     public sealed class TerminalCreateParams
     {
-        [JsonPropertyName("command")]
+        [JsonProperty("command")]
         public string Command { get; set; } = "";
 
-        [JsonPropertyName("cwd")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("cwd", NullValueHandling = NullValueHandling.Ignore)]
         public string Cwd { get; set; }
 
-        [JsonPropertyName("env")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("env", NullValueHandling = NullValueHandling.Ignore)]
         public Dictionary<string, string> Env { get; set; }
     }
 
     public sealed class TerminalCreateResult
     {
-        [JsonPropertyName("terminalId")]
+        [JsonProperty("terminalId")]
         public string TerminalId { get; set; } = "";
     }
 
     public sealed class TerminalGetOutputParams
     {
-        [JsonPropertyName("terminalId")]
+        [JsonProperty("terminalId")]
         public string TerminalId { get; set; } = "";
     }
 
     public sealed class TerminalGetOutputResult
     {
-        [JsonPropertyName("output")]
+        [JsonProperty("output")]
         public string Output { get; set; } = "";
 
-        [JsonPropertyName("exitCode")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("exitCode", NullValueHandling = NullValueHandling.Ignore)]
         public int? ExitCode { get; set; }
     }
 
     public sealed class TerminalWaitForExitParams
     {
-        [JsonPropertyName("terminalId")]
+        [JsonProperty("terminalId")]
         public string TerminalId { get; set; } = "";
 
-        [JsonPropertyName("timeout")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("timeout", NullValueHandling = NullValueHandling.Ignore)]
         public int? Timeout { get; set; }
     }
 
     public sealed class TerminalKillParams
     {
-        [JsonPropertyName("terminalId")]
+        [JsonProperty("terminalId")]
         public string TerminalId { get; set; } = "";
     }
 
     public sealed class TerminalReleaseParams
     {
-        [JsonPropertyName("terminalId")]
+        [JsonProperty("terminalId")]
         public string TerminalId { get; set; } = "";
     }
 
@@ -756,15 +715,13 @@ namespace DotCraft.Editor.Protocol
 
     public sealed class AcpSlashCommand
     {
-        [JsonPropertyName("name")]
+        [JsonProperty("name")]
         public string Name { get; set; } = "";
 
-        [JsonPropertyName("description")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("description", NullValueHandling = NullValueHandling.Ignore)]
         public string Description { get; set; }
 
-        [JsonPropertyName("inputHint")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("inputHint", NullValueHandling = NullValueHandling.Ignore)]
         public string InputHint { get; set; }
     }
 
@@ -774,40 +731,37 @@ namespace DotCraft.Editor.Protocol
 
     public sealed class ConfigOption
     {
-        [JsonPropertyName("id")]
+        [JsonProperty("id")]
         public string Id { get; set; } = "";
 
-        [JsonPropertyName("name")]
+        [JsonProperty("name")]
         public string Name { get; set; } = "";
 
-        [JsonPropertyName("description")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("description", NullValueHandling = NullValueHandling.Ignore)]
         public string Description { get; set; }
 
-        [JsonPropertyName("category")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("category", NullValueHandling = NullValueHandling.Ignore)]
         public string Category { get; set; }
 
-        [JsonPropertyName("type")]
+        [JsonProperty("type")]
         public string Type { get; set; } = "select";
 
-        [JsonPropertyName("currentValue")]
+        [JsonProperty("currentValue")]
         public string CurrentValue { get; set; } = "";
 
-        [JsonPropertyName("options")]
+        [JsonProperty("options")]
         public List<ConfigOptionValue> Options { get; set; } = new();
     }
 
     public sealed class ConfigOptionValue
     {
-        [JsonPropertyName("value")]
+        [JsonProperty("value")]
         public string Value { get; set; } = "";
 
-        [JsonPropertyName("name")]
+        [JsonProperty("name")]
         public string Name { get; set; } = "";
 
-        [JsonPropertyName("description")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("description", NullValueHandling = NullValueHandling.Ignore)]
         public string Description { get; set; }
     }
 

--- a/Editor/Protocol/DotCraftJson.cs
+++ b/Editor/Protocol/DotCraftJson.cs
@@ -1,0 +1,46 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
+
+namespace DotCraft.Editor.Protocol
+{
+    internal static class DotCraftJson
+    {
+        private static readonly DefaultContractResolver CamelCaseContractResolver = new()
+        {
+            NamingStrategy = new CamelCaseNamingStrategy
+            {
+                ProcessDictionaryKeys = false,
+                OverrideSpecifiedNames = false
+            }
+        };
+
+        public static readonly JsonSerializerSettings CompactSettings = CreateSettings(Formatting.None);
+        public static readonly JsonSerializerSettings IndentedSettings = CreateSettings(Formatting.Indented);
+        public static readonly JsonSerializer CompactSerializer = JsonSerializer.Create(CompactSettings);
+
+        private static JsonSerializerSettings CreateSettings(Formatting formatting)
+        {
+            return new JsonSerializerSettings
+            {
+                ContractResolver = CamelCaseContractResolver,
+                NullValueHandling = NullValueHandling.Ignore,
+                Formatting = formatting
+            };
+        }
+
+        public static string Serialize(object value) =>
+            JsonConvert.SerializeObject(value, CompactSettings);
+
+        public static string SerializeIndented(object value) =>
+            JsonConvert.SerializeObject(value, IndentedSettings);
+
+        public static T Deserialize<T>(string json) =>
+            JsonConvert.DeserializeObject<T>(json, CompactSettings);
+
+        public static T ToObject<T>(JToken token) =>
+            token == null || token.Type == JTokenType.Null
+                ? default
+                : token.ToObject<T>(CompactSerializer);
+    }
+}

--- a/Editor/Protocol/DotCraftJson.cs.meta
+++ b/Editor/Protocol/DotCraftJson.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 90d9d55b690b40e5a40b610a6ded0f3c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Protocol/JsonRpcTypes.cs
+++ b/Editor/Protocol/JsonRpcTypes.cs
@@ -1,5 +1,5 @@
-using System.Text.Json;
-using System.Text.Json.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace DotCraft.Editor.Protocol
 {
@@ -10,20 +10,20 @@ namespace DotCraft.Editor.Protocol
     /// </summary>
     public sealed class JsonRpcRequest
     {
-        [JsonPropertyName("jsonrpc")]
+        [JsonProperty("jsonrpc")]
         public string JsonRpc { get; set; } = "2.0";
 
-        [JsonPropertyName("id")]
-        public JsonElement? Id { get; set; }
+        [JsonProperty("id")]
+        public JToken Id { get; set; }
 
-        [JsonPropertyName("method")]
+        [JsonProperty("method")]
         public string Method { get; set; } = "";
 
-        [JsonPropertyName("params")]
-        public JsonElement? Params { get; set; }
+        [JsonProperty("params")]
+        public JToken Params { get; set; }
 
         [JsonIgnore]
-        public bool IsNotification => Id is null || Id.Value.ValueKind == JsonValueKind.Undefined;
+        public bool IsNotification => Id == null || Id.Type == JTokenType.Null || Id.Type == JTokenType.Undefined;
     }
 
     /// <summary>
@@ -31,18 +31,16 @@ namespace DotCraft.Editor.Protocol
     /// </summary>
     public sealed class JsonRpcResponse
     {
-        [JsonPropertyName("jsonrpc")]
+        [JsonProperty("jsonrpc")]
         public string JsonRpc { get; set; } = "2.0";
 
-        [JsonPropertyName("id")]
-        public JsonElement? Id { get; set; }
+        [JsonProperty("id")]
+        public JToken Id { get; set; }
 
-        [JsonPropertyName("result")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("result", NullValueHandling = NullValueHandling.Ignore)]
         public object Result { get; set; }
 
-        [JsonPropertyName("error")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("error", NullValueHandling = NullValueHandling.Ignore)]
         public JsonRpcError Error { get; set; }
     }
 
@@ -51,14 +49,13 @@ namespace DotCraft.Editor.Protocol
     /// </summary>
     public sealed class JsonRpcError
     {
-        [JsonPropertyName("code")]
+        [JsonProperty("code")]
         public int Code { get; set; }
 
-        [JsonPropertyName("message")]
+        [JsonProperty("message")]
         public string Message { get; set; } = "";
 
-        [JsonPropertyName("data")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("data", NullValueHandling = NullValueHandling.Ignore)]
         public object Data { get; set; }
     }
 
@@ -67,14 +64,13 @@ namespace DotCraft.Editor.Protocol
     /// </summary>
     public sealed class JsonRpcNotification
     {
-        [JsonPropertyName("jsonrpc")]
+        [JsonProperty("jsonrpc")]
         public string JsonRpc { get; set; } = "2.0";
 
-        [JsonPropertyName("method")]
+        [JsonProperty("method")]
         public string Method { get; set; } = "";
 
-        [JsonPropertyName("params")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("params", NullValueHandling = NullValueHandling.Ignore)]
         public object Params { get; set; }
     }
 

--- a/Editor/Settings/DotCraftSettings.cs
+++ b/Editor/Settings/DotCraftSettings.cs
@@ -1,8 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text.Json;
-using System.Text.Json.Serialization;
+using DotCraft.Editor.Protocol;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEngine;
 
@@ -16,44 +17,39 @@ namespace DotCraft.Editor.Settings
     public sealed class McpServerEntry
     {
         /// <summary>Display name for the server (used as the MCP server name in the ACP protocol).</summary>
-        [JsonPropertyName("name")]
+        [JsonProperty("name")]
         public string Name { get; set; } = "";
 
         /// <summary>Whether this server is included when creating or loading sessions.</summary>
-        [JsonPropertyName("enabled")]
+        [JsonProperty("enabled")]
         public bool Enabled { get; set; } = true;
 
         /// <summary>Transport type: "stdio" or "http".</summary>
-        [JsonPropertyName("transport")]
+        [JsonProperty("transport")]
         public string Transport { get; set; } = "stdio";
 
         // stdio-specific fields
 
         /// <summary>Executable command (stdio transport only).</summary>
-        [JsonPropertyName("command")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("command", NullValueHandling = NullValueHandling.Ignore)]
         public string Command { get; set; }
 
         /// <summary>Command-line arguments (stdio transport only).</summary>
-        [JsonPropertyName("arguments")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("arguments", NullValueHandling = NullValueHandling.Ignore)]
         public List<string> Arguments { get; set; }
 
         /// <summary>Environment variables to inject into the server process (stdio transport only).</summary>
-        [JsonPropertyName("environmentVariables")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("environmentVariables", NullValueHandling = NullValueHandling.Ignore)]
         public Dictionary<string, string> EnvironmentVariables { get; set; }
 
         // http-specific fields
 
         /// <summary>Server URL (http transport only).</summary>
-        [JsonPropertyName("url")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("url", NullValueHandling = NullValueHandling.Ignore)]
         public string Url { get; set; }
 
         /// <summary>HTTP headers (http transport only).</summary>
-        [JsonPropertyName("headers")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonProperty("headers", NullValueHandling = NullValueHandling.Ignore)]
         public Dictionary<string, string> Headers { get; set; }
     }
 
@@ -68,13 +64,6 @@ namespace DotCraft.Editor.Settings
         public const string AgentConnectionCustomAcp = "customAcp";
         public const string DotCraftAppServerLocalHub = "localHub";
         public const string DotCraftAppServerRemote = "remote";
-
-        private static readonly JsonSerializerOptions JsonOptions = new()
-        {
-            WriteIndented = true,
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-        };
 
         private static DotCraftSettings _instance;
         private static readonly string SettingsPath = "UserSettings/DotCraftSettings.json";
@@ -96,96 +85,96 @@ namespace DotCraft.Editor.Settings
         /// "dotcraft" uses DotCraft-specific Hub discovery before starting the ACP bridge.
         /// "customAcp" preserves the raw command/arguments startup path for other ACP agents.
         /// </summary>
-        [JsonPropertyName("agentConnection")]
+        [JsonProperty("agentConnection")]
         public string AgentConnection { get; set; } = AgentConnectionDotCraft;
 
         /// <summary>
         /// DotCraft AppServer discovery mode when AgentConnection is "dotcraft".
         /// </summary>
-        [JsonPropertyName("dotCraftAppServer")]
+        [JsonProperty("dotCraftAppServer")]
         public string DotCraftAppServer { get; set; } = DotCraftAppServerLocalHub;
 
         /// <summary>
         /// Command to execute DotCraft (e.g., "dotnet" or full path to executable).
         /// </summary>
-        [JsonPropertyName("dotCraftCommand")]
+        [JsonProperty("dotCraftCommand")]
         public string DotCraftCommand { get; set; } = "dotcraft";
 
         /// <summary>
         /// Arguments passed to DotCraft command.
         /// Example: "run --project /path/to/DotCraft -- --acp"
         /// </summary>
-        [JsonPropertyName("dotCraftArguments")]
+        [JsonProperty("dotCraftArguments")]
         public string DotCraftArguments { get; set; } = "-acp";
 
         /// <summary>
         /// Remote AppServer WebSocket URL used by DotCraft remote mode.
         /// </summary>
-        [JsonPropertyName("remoteAppServerUrl")]
+        [JsonProperty("remoteAppServerUrl")]
         public string RemoteAppServerUrl { get; set; } = "";
 
         /// <summary>
         /// Optional token used by DotCraft remote AppServer mode.
         /// </summary>
-        [JsonPropertyName("remoteAppServerToken")]
+        [JsonProperty("remoteAppServerToken")]
         public string RemoteAppServerToken { get; set; } = "";
 
         /// <summary>
         /// Working directory for DotCraft process. Defaults to Unity project root.
         /// </summary>
-        [JsonPropertyName("workspacePath")]
+        [JsonProperty("workspacePath")]
         public string WorkspacePath { get; set; } = "";
 
         /// <summary>
         /// Environment variables to inject into DotCraft process.
         /// Use for API keys and other configuration.
         /// </summary>
-        [JsonPropertyName("environmentVariables")]
+        [JsonProperty("environmentVariables")]
         public Dictionary<string, string> EnvironmentVariables { get; set; } = new();
 
         /// <summary>
         /// Automatically reconnect after Domain Reload.
         /// </summary>
-        [JsonPropertyName("autoReconnect")]
+        [JsonProperty("autoReconnect")]
         public bool AutoReconnect { get; set; } = true;
 
         /// <summary>
         /// Enable verbose logging for debugging.
         /// </summary>
-        [JsonPropertyName("verboseLogging")]
+        [JsonProperty("verboseLogging")]
         public bool VerboseLogging { get; set; } = false;
 
         /// <summary>
         /// Show agent reasoning text in the chat UI.
         /// When disabled, the chat still shows lightweight thinking status rows.
         /// </summary>
-        [JsonPropertyName("showThinkingContent")]
+        [JsonProperty("showThinkingContent")]
         public bool ShowThinkingContent { get; set; } = false;
 
         /// <summary>
         /// Timeout in seconds for ACP requests.
         /// </summary>
-        [JsonPropertyName("requestTimeoutSeconds")]
+        [JsonProperty("requestTimeoutSeconds")]
         public int RequestTimeoutSeconds { get; set; } = 30;
 
         /// <summary>
         /// Maximum number of messages to keep in chat history.
         /// </summary>
-        [JsonPropertyName("maxHistoryMessages")]
+        [JsonProperty("maxHistoryMessages")]
         public int MaxHistoryMessages { get; set; } = 1000;
 
         /// <summary>
         /// Declare built-in Unity runtime tools and enable their _unity/* handlers.
         /// Disable if using external Unity integration.
         /// </summary>
-        [JsonPropertyName("enableBuiltinUnityTools")]
+        [JsonProperty("enableBuiltinUnityTools")]
         public bool EnableBuiltinUnityTools { get; set; } = true;
 
         /// <summary>
         /// MCP servers to inject into every new DotCraft session via the ACP mcpServers field.
         /// These supplement any servers already configured in .craft/config.json.
         /// </summary>
-        [JsonPropertyName("mcpServers")]
+        [JsonProperty("mcpServers")]
         public List<McpServerEntry> McpServers { get; set; } = new();
 
         /// <summary>
@@ -207,11 +196,7 @@ namespace DotCraft.Editor.Settings
                 try
                 {
                     var json = File.ReadAllText(SettingsPath);
-                    var hasAgentConnection = HasJsonProperty(json, "agentConnection");
-                    var settings = JsonSerializer.Deserialize<DotCraftSettings>(json, JsonOptions);
-                    settings ??= new DotCraftSettings();
-                    settings.NormalizeAfterLoad(hasAgentConnection);
-                    return settings;
+                    return FromJson(json);
                 }
                 catch (Exception ex)
                 {
@@ -222,13 +207,21 @@ namespace DotCraft.Editor.Settings
             return new DotCraftSettings();
         }
 
+        internal static DotCraftSettings FromJson(string json)
+        {
+            var hasAgentConnection = HasJsonProperty(json, "agentConnection");
+            var settings = DotCraftJson.Deserialize<DotCraftSettings>(json) ?? new DotCraftSettings();
+            settings.NormalizeAfterLoad(hasAgentConnection);
+            return settings;
+        }
+
+        internal string ToJson() => DotCraftJson.SerializeIndented(this);
+
         private static bool HasJsonProperty(string json, string propertyName)
         {
             try
             {
-                using var doc = JsonDocument.Parse(json);
-                return doc.RootElement.ValueKind == JsonValueKind.Object
-                       && doc.RootElement.TryGetProperty(propertyName, out _);
+                return JObject.Parse(json).Property(propertyName) != null;
             }
             catch
             {
@@ -280,8 +273,7 @@ namespace DotCraft.Editor.Settings
                     Directory.CreateDirectory(directory);
                 }
 
-                var json = JsonSerializer.Serialize(this, JsonOptions);
-                File.WriteAllText(SettingsPath, json);
+                File.WriteAllText(SettingsPath, ToJson());
             }
             catch (Exception ex)
             {

--- a/Editor/Settings/DotCraftSettings.cs
+++ b/Editor/Settings/DotCraftSettings.cs
@@ -175,7 +175,7 @@ namespace DotCraft.Editor.Settings
         public int MaxHistoryMessages { get; set; } = 1000;
 
         /// <summary>
-        /// Enable built-in Unity tools (_unity/* extension methods).
+        /// Declare built-in Unity runtime tools and enable their _unity/* handlers.
         /// Disable if using external Unity integration.
         /// </summary>
         [JsonPropertyName("enableBuiltinUnityTools")]

--- a/Editor/Settings/DotCraftSettingsProvider.cs
+++ b/Editor/Settings/DotCraftSettingsProvider.cs
@@ -72,7 +72,7 @@ namespace DotCraft.Editor.Settings
 
         public override void OnGUI(string searchContext)
         {
-            // Using IMGUI fallback for compatibility
+            // Draw the Project Settings panel with IMGUI.
             EditorGUI.BeginChangeCheck();
 
             EditorGUILayout.Space(10);
@@ -177,8 +177,7 @@ namespace DotCraft.Editor.Settings
 
                 _settings.EnableBuiltinUnityTools = EditorGUILayout.Toggle(
                     new GUIContent("Enable Builtin Tools",
-                        "Enable built-in _unity/* extension methods for reading Unity state. " +
-                        "Disable if using external Unity integration."),
+                        "Declare built-in read-only Unity runtime tools and enable their _unity/* handlers."),
                     _settings.EnableBuiltinUnityTools);
 
                 EditorGUI.indentLevel--;
@@ -300,12 +299,12 @@ namespace DotCraft.Editor.Settings
             EditorGUI.indentLevel--;
         }
 
-        private static int IndexOfOrDefault(string[] options, string value, string fallback)
+        private static int IndexOfOrDefault(string[] options, string value, string defaultValue)
         {
             var index = Array.IndexOf(options, value);
             if (index >= 0)
                 return index;
-            index = Array.IndexOf(options, fallback);
+            index = Array.IndexOf(options, defaultValue);
             return index >= 0 ? index : 0;
         }
 

--- a/Editor/UI/ChatPanel.cs
+++ b/Editor/UI/ChatPanel.cs
@@ -3,10 +3,11 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
-using System.Text.Json;
 using System.Text.RegularExpressions;
 using DotCraft.Editor.Protocol;
 using DotCraft.Editor.Settings;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.UIElements;
@@ -49,13 +50,6 @@ namespace DotCraft.Editor.UI
         private VisualElement _typingIndicator;
         private VisualElement _reasoningSpinner;
         private Label _reasoningLabel;
-
-        private static readonly JsonSerializerOptions JsonOptions = new()
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            PropertyNameCaseInsensitive = true,
-            WriteIndented = true
-        };
 
         public ChatPanel(ScrollView container)
         {
@@ -352,7 +346,7 @@ namespace DotCraft.Editor.UI
             {
                 try
                 {
-                    var contentJson = JsonSerializer.Serialize(update.Content, JsonOptions);
+                    var contentJson = DotCraftJson.SerializeIndented(update.Content);
                     toolCall.SetOutput(contentJson);
                 }
                 catch { }
@@ -417,7 +411,7 @@ namespace DotCraft.Editor.UI
             {
                 try
                 {
-                    var contentJson = JsonSerializer.Serialize(update.Content, JsonOptions);
+                    var contentJson = DotCraftJson.SerializeIndented(update.Content);
                     target.AppendOutput(contentJson);
                 }
                 catch { }
@@ -447,16 +441,20 @@ namespace DotCraft.Editor.UI
         {
             if (content == null) return "";
 
-            if (content is JsonElement json)
+            if (content is JToken json)
             {
-                if (json.ValueKind == JsonValueKind.Object)
+                if (json.Type == JTokenType.Object)
                 {
-                    if (json.TryGetProperty("text", out var textProp))
+                    var textProp = json["text"];
+                    if (textProp != null)
                     {
-                        return textProp.GetString() ?? "";
+                        return textProp.ToObject<string>() ?? "";
                     }
                 }
-                return json.ToString();
+
+                return json.Type == JTokenType.String
+                    ? json.ToObject<string>() ?? ""
+                    : json.ToString(Formatting.None);
             }
 
             return content.ToString();

--- a/Editor/Window/DotCraftEditorWindow.cs
+++ b/Editor/Window/DotCraftEditorWindow.cs
@@ -1,13 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.Json;
 using System.Threading.Tasks;
 using DotCraft.Editor.Connection;
 using DotCraft.Editor.Extensions;
 using DotCraft.Editor.Protocol;
 using DotCraft.Editor.Settings;
 using DotCraft.Editor.UI;
+using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -805,15 +805,15 @@ namespace DotCraft.Editor.Window
         private void HandleModeUpdate(AcpSessionUpdate update)
         {
             string modeText = null;
-            if (update.Content is JsonElement json)
+            if (update.Content is JToken json)
             {
-                if (json.ValueKind == JsonValueKind.Object && json.TryGetProperty("text", out var textProp))
+                if (json.Type == JTokenType.Object && json["text"] is JToken textProp)
                 {
-                    modeText = textProp.GetString();
+                    modeText = textProp.ToObject<string>();
                 }
-                else if (json.ValueKind == JsonValueKind.String)
+                else if (json.Type == JTokenType.String)
                 {
-                    modeText = json.GetString();
+                    modeText = json.ToObject<string>();
                 }
             }
             else if (update.Content is string text)

--- a/Editor/Window/DotCraftEditorWindow.cs
+++ b/Editor/Window/DotCraftEditorWindow.cs
@@ -13,6 +13,9 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.UIElements;
 using UObject = UnityEngine.Object;
+#if !UNITY_6000_3_OR_NEWER
+using UnityEditor.UIElements;
+#endif
 
 namespace DotCraft.Editor.Window
 {

--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ Open **Edit → Project Settings → DotCraft** to configure the client.
 | **Auto Reconnect** | `true` | Reconnect after Unity Domain Reload. |
 | **Verbose Logging** | `false` | Print DotCraft stderr to the Unity Console. |
 | **Show Thinking Content** | `false` | Show agent reasoning text in expandable chat rows. When disabled, only lightweight thinking status is shown. |
-| **Enable Builtin Unity Tools** | `true` | Enable the built-in `_unity/*` read-only tools. |
+| **Enable Builtin Unity Tools** | `true` | Declare the built-in read-only Unity runtime tools and enable their `_unity/*` handlers. |
 
 For API keys, prefer environment variables in Project Settings instead of committing secrets to project files.
 
 ## Built-in Tools
 
-dotcraft-unity exposes four read-only Unity tools to DotCraft:
+dotcraft-unity declares four read-only Unity runtime tools to DotCraft during ACP initialization:
 
 | Tool | Description |
 |------|-------------|
@@ -62,7 +62,7 @@ dotcraft-unity exposes four read-only Unity tools to DotCraft:
 | `unity_get_console_logs` | Retrieve recent Unity Console log entries. |
 | `unity_get_project_info` | Read Unity version, project name, and package information. |
 
-These tools help DotCraft understand the current scene and project state. For full Unity editing automation, combine DotCraft with a dedicated Unity tool package such as [SkillsForUnity](https://github.com/BestyAIGC/Unity-Skills) or [unity-mcp](https://github.com/CoplayDev/unity-mcp).
+These tools help DotCraft understand the current scene and project state. The model-visible tool descriptors live in this Unity client; the `_unity/*` ACP methods are private callbacks used to execute them. For full Unity editing automation, combine DotCraft with a dedicated Unity tool package such as [SkillsForUnity](https://github.com/BestyAIGC/Unity-Skills) or [unity-mcp](https://github.com/CoplayDev/unity-mcp).
 
 ## Troubleshooting
 
@@ -71,7 +71,7 @@ These tools help DotCraft understand the current scene and project state. For fu
 | `Failed to start DotCraft process` | `dotcraft` is not on `PATH` | Install DotCraft and add it to `PATH`, or set a full path in **Command**. |
 | Stuck at `Connecting...` | DotCraft failed during startup | Enable **Verbose Logging** and check the Unity Console. |
 | Disconnects after script compilation | Auto reconnect is disabled | Enable **Auto Reconnect** in Project Settings. |
-| Tools are unavailable | The ACP client did not advertise `_unity` extensions | Make sure the DotCraft ACP process starts successfully. |
+| Tools are unavailable | Runtime tool descriptors were not declared or accepted | Enable **Builtin Unity Tools** and use a DotCraft version that supports runtime dynamic tools over ACP. |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -20,15 +20,16 @@ dotcraft-unity is the Unity editor client for [DotCraft](https://github.com/DotH
 ## Get Started
 
 1. Install and configure [DotCraft](https://github.com/DotHarness/dotcraft).
-2. In Unity, install `System.Text.Json 9.0.10` via [NuGetForUnity](https://github.com/GlitchEnzo/NuGetForUnity).
-3. Open **Window → Package Manager** and add this Git URL:
+2. Open **Window → Package Manager** and add this Git URL:
 
    ```text
    https://github.com/DotHarness/dotcraft-unity.git
    ```
 
-4. Open **Tools → DotCraft Assistant**.
-5. Click **Connect**, then start a conversation from the Unity Editor.
+   Unity resolves the official `com.unity.nuget.newtonsoft-json` dependency automatically.
+
+3. Open **Tools → DotCraft Assistant**.
+4. Click **Connect**, then start a conversation from the Unity Editor.
 
 Minimum Unity version: **2022.3**, recommended version: **Unity 6**.
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -21,15 +21,16 @@ dotcraft-unity 是 [DotCraft](https://github.com/DotHarness/dotcraft) 的 Unity 
 ## 快速开始
 
 1. 安装并配置 [DotCraft](https://github.com/DotHarness/dotcraft)。
-2. 在 Unity 中通过 [NuGetForUnity](https://github.com/GlitchEnzo/NuGetForUnity) 安装 `System.Text.Json 9.0.10`。
-3. 打开 **Window → Package Manager**，添加这个 Git URL：
+2. 打开 **Window → Package Manager**，添加这个 Git URL：
 
    ```text
    https://github.com/DotHarness/dotcraft-unity.git
    ```
 
-4. 打开 **Tools → DotCraft Assistant**。
-5. 点击 **Connect**，然后在 Unity 编辑器中开始对话。
+   Unity 会自动解析官方 `com.unity.nuget.newtonsoft-json` 依赖。
+
+3. 打开 **Tools → DotCraft Assistant**。
+4. 点击 **Connect**，然后在 Unity 编辑器中开始对话。
 
 最低 Unity 版本：**2022.3**，推荐版本 **Unity 6**。
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -48,13 +48,13 @@ dotcraft-unity 是 [DotCraft](https://github.com/DotHarness/dotcraft) 的 Unity 
 | **Auto Reconnect** | `true` | Unity Domain Reload 后自动重连。 |
 | **Verbose Logging** | `false` | 将 DotCraft stderr 输出到 Unity Console。 |
 | **Show Thinking Content** | `false` | 在可展开的聊天行中显示 agent 思考内容。关闭时仅显示轻量的思考状态。 |
-| **Enable Builtin Unity Tools** | `true` | 启用内置 `_unity/*` 只读工具。 |
+| **Enable Builtin Unity Tools** | `true` | 声明内置只读 Unity 运行时工具，并启用对应的 `_unity/*` 处理器。 |
 
 配置 API key 时，建议使用 Project Settings 里的环境变量，不要把密钥提交到项目文件。
 
 ## 内置工具
 
-dotcraft-unity 向 DotCraft 暴露四个只读 Unity 工具：
+dotcraft-unity 会在 ACP 初始化时向 DotCraft 声明四个只读 Unity 运行时工具：
 
 | 工具 | 描述 |
 |------|------|
@@ -63,7 +63,7 @@ dotcraft-unity 向 DotCraft 暴露四个只读 Unity 工具：
 | `unity_get_console_logs` | 获取最近的 Unity Console 日志。 |
 | `unity_get_project_info` | 读取 Unity 版本、项目名称和包信息。 |
 
-这些工具帮助 DotCraft 理解当前场景与项目状态。如需完整 Unity 编辑自动化能力，可以将 DotCraft 与 [SkillsForUnity](https://github.com/BestyAIGC/Unity-Skills) 或 [unity-mcp](https://github.com/CoplayDev/unity-mcp) 等专用 Unity 工具包配合使用。
+这些工具帮助 DotCraft 理解当前场景与项目状态。模型可见的工具描述符位于这个 Unity 客户端中；`_unity/*` ACP 方法只是执行这些工具时使用的私有回调。如需完整 Unity 编辑自动化能力，可以将 DotCraft 与 [SkillsForUnity](https://github.com/BestyAIGC/Unity-Skills) 或 [unity-mcp](https://github.com/CoplayDev/unity-mcp) 等专用 Unity 工具包配合使用。
 
 ## 故障排除
 
@@ -72,7 +72,7 @@ dotcraft-unity 向 DotCraft 暴露四个只读 Unity 工具：
 | `Failed to start DotCraft process` | `dotcraft` 不在 `PATH` 中 | 安装 DotCraft 并加入 `PATH`，或在 **Command** 中设置完整路径。 |
 | 卡在 `Connecting...` | DotCraft 启动失败 | 启用 **Verbose Logging** 并查看 Unity Console。 |
 | 脚本编译后断开连接 | 自动重连已关闭 | 在 Project Settings 中启用 **Auto Reconnect**。 |
-| 工具不可用 | ACP 客户端没有声明 `_unity` 扩展 | 确保 DotCraft ACP 进程成功启动。 |
+| 工具不可用 | 运行时工具描述符没有声明或没有被接受 | 启用 **Builtin Unity Tools**，并使用支持 ACP runtime dynamic tools 的 DotCraft 版本。 |
 
 ## 贡献代码
 

--- a/Tests.meta
+++ b/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9cefd8cf5f064ac48125c6bdf3cb1a17
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor.meta
+++ b/Tests/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 01f4d25096be4ff88ab655042d4eac6e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/AcpDtoSerializationTests.cs
+++ b/Tests/Editor/AcpDtoSerializationTests.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using DotCraft.Editor.Protocol;
+using NUnit.Framework;
+
+namespace DotCraft.Editor.Tests
+{
+    public sealed class AcpDtoSerializationTests
+    {
+        [Test]
+        public void BoolOrObjectConverterReadsBooleanCapabilityShorthand()
+        {
+            var json =
+                "{\"protocolVersion\":1,\"clientCapabilities\":{\"fs\":true,\"terminal\":false},\"clientInfo\":{\"name\":\"DotCraft-Unity\"}}";
+
+            var parameters = DotCraftJson.Deserialize<InitializeParams>(json);
+
+            Assert.That(parameters.ClientCapabilities.Fs.ReadTextFile, Is.True);
+            Assert.That(parameters.ClientCapabilities.Fs.WriteTextFile, Is.True);
+            Assert.That(parameters.ClientCapabilities.Terminal, Is.Null);
+        }
+
+        [Test]
+        public void RuntimeToolDescriptorUsesProtocolNamesAndOmitsNulls()
+        {
+            var descriptor = new AcpRuntimeToolDescriptor
+            {
+                Namespace = "unity",
+                Name = "unity_scene_query",
+                Description = "Query scene hierarchy.",
+                InputSchema = new Dictionary<string, object>
+                {
+                    ["type"] = "object",
+                    ["properties"] = new Dictionary<string, object>
+                    {
+                        ["includeComponents"] = new Dictionary<string, object>
+                        {
+                            ["type"] = "boolean"
+                        }
+                    }
+                },
+                AcpMethod = "_unity/scene_query",
+                Kind = AcpToolKind.Unity
+            };
+
+            var json = DotCraftJson.Serialize(descriptor);
+
+            Assert.That(json, Does.Contain("\"inputSchema\""));
+            Assert.That(json, Does.Contain("\"acpMethod\":\"_unity/scene_query\""));
+            Assert.That(json, Does.Contain("\"includeComponents\""));
+            Assert.That(json, Does.Not.Contain("deferLoading"));
+            Assert.That(json, Does.Not.Contain("approval"));
+        }
+    }
+}

--- a/Tests/Editor/AcpDtoSerializationTests.cs.meta
+++ b/Tests/Editor/AcpDtoSerializationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4e272a9c20184177b793f8344ab92922
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/DotCraft.Editor.Tests.asmdef
+++ b/Tests/Editor/DotCraft.Editor.Tests.asmdef
@@ -1,0 +1,21 @@
+{
+    "name": "DotCraft.Editor.Tests",
+    "rootNamespace": "DotCraft.Editor.Tests",
+    "references": [
+        "DotCraft.Editor"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ],
+    "noEngineReferences": false
+}

--- a/Tests/Editor/DotCraft.Editor.Tests.asmdef.meta
+++ b/Tests/Editor/DotCraft.Editor.Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d3f34b22841346fea2ef4f9d6b0af5f2
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/JsonRpcSerializationTests.cs
+++ b/Tests/Editor/JsonRpcSerializationTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using DotCraft.Editor.Connection;
+using DotCraft.Editor.Protocol;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace DotCraft.Editor.Tests
+{
+    public sealed class JsonRpcSerializationTests
+    {
+        [Test]
+        public void NotificationSerializationOmitsNullParams()
+        {
+            var json = DotCraftJson.Serialize(new JsonRpcNotification
+            {
+                Method = "session/cancel"
+            });
+
+            Assert.That(json, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"method\":\"session/cancel\"}"));
+        }
+
+        [Test]
+        public void ProcessMessageSkipsNonJsonStdoutLines()
+        {
+            var transport = new AcpTransportClient();
+
+            Assert.DoesNotThrow(() => transport.ProcessMessage("DotCraft starting..."));
+        }
+
+        [Test]
+        public void ProcessMessageRaisesNotificationWithJTokenParams()
+        {
+            var transport = new AcpTransportClient();
+            string method = null;
+            JToken parameters = null;
+            transport.OnNotification += (m, p) =>
+            {
+                method = m;
+                parameters = p;
+            };
+
+            transport.ProcessMessage(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"session/update\",\"params\":{\"sessionId\":\"s\",\"update\":{\"sessionUpdate\":\"agent_message_chunk\",\"content\":{\"text\":\"hi\"}}}}");
+
+            Assert.That(method, Is.EqualTo("session/update"));
+            Assert.That(parameters?["update"]?["content"]?["text"]?.ToObject<string>(), Is.EqualTo("hi"));
+        }
+
+        [Test]
+        public async Task SendRequestCompletesPendingRequestOnNumericIdResponse()
+        {
+            var transport = new AcpTransportClient();
+            using var input = new MemoryStream();
+            using var output = new MemoryStream();
+            transport.Initialize(input, output);
+
+            var request = transport.SendRequestAsync(
+                "initialize",
+                new { protocolVersion = 1 },
+                timeout: TimeSpan.FromSeconds(1));
+
+            transport.ProcessMessage("{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"ok\":true}}");
+
+            var result = await request;
+            Assert.That(result?["ok"]?.ToObject<bool>(), Is.True);
+
+            var written = Encoding.UTF8.GetString(output.ToArray()).Trim();
+            Assert.That(written, Does.Contain("\"method\":\"initialize\""));
+            Assert.That(written, Does.Contain("\"params\":{\"protocolVersion\":1}"));
+        }
+    }
+}

--- a/Tests/Editor/JsonRpcSerializationTests.cs.meta
+++ b/Tests/Editor/JsonRpcSerializationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c2b760819c1e4c0f9ec65d9382b9c5e5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/SettingsSerializationTests.cs
+++ b/Tests/Editor/SettingsSerializationTests.cs
@@ -1,0 +1,32 @@
+using DotCraft.Editor.Settings;
+using NUnit.Framework;
+
+namespace DotCraft.Editor.Tests
+{
+    public sealed class SettingsSerializationTests
+    {
+        [Test]
+        public void LegacySettingsWithoutAgentConnectionAreNormalized()
+        {
+            var settings = DotCraftSettings.FromJson(
+                "{\"dotCraftCommand\":\"dotcraft\",\"dotCraftArguments\":\"-acp\"}");
+
+            Assert.That(settings.AgentConnection, Is.EqualTo(DotCraftSettings.AgentConnectionDotCraft));
+            Assert.That(settings.DotCraftAppServer, Is.EqualTo(DotCraftSettings.DotCraftAppServerLocalHub));
+        }
+
+        [Test]
+        public void SettingsSerializationPreservesDictionaryKeysAndOmitsNulls()
+        {
+            var settings = DotCraftSettings.FromJson(
+                "{\"agentConnection\":\"customAcp\",\"dotCraftCommand\":\"agent\",\"dotCraftArguments\":\"--acp\",\"environmentVariables\":{\"OPENAI_API_KEY\":\"secret\"},\"mcpServers\":[{\"name\":\"local\",\"enabled\":true,\"transport\":\"stdio\",\"environmentVariables\":{\"MY_CUSTOM_KEY\":\"value\"}}]}");
+
+            var json = settings.ToJson();
+
+            Assert.That(json, Does.Contain("\"OPENAI_API_KEY\""));
+            Assert.That(json, Does.Contain("\"MY_CUSTOM_KEY\""));
+            Assert.That(json, Does.Not.Contain("\"url\": null"));
+            Assert.That(json, Does.Not.Contain("\"headers\": null"));
+        }
+    }
+}

--- a/Tests/Editor/SettingsSerializationTests.cs.meta
+++ b/Tests/Editor/SettingsSerializationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 76bda8f5a22645b6bcf74e9456498f24
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/UnityToolParameterTests.cs
+++ b/Tests/Editor/UnityToolParameterTests.cs
@@ -1,0 +1,30 @@
+using DotCraft.Editor.Extensions;
+using DotCraft.Editor.Protocol;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace DotCraft.Editor.Tests
+{
+    public sealed class UnityToolParameterTests
+    {
+        [Test]
+        public void SceneQueryAcceptsMissingOptionalParameters()
+        {
+            var result = UnitySceneHandlers.HandleSceneQuery(new JObject()).Result;
+            var json = DotCraftJson.Serialize(result);
+
+            Assert.That(json, Does.Contain("\"objects\""));
+        }
+
+        [Test]
+        public void ConsoleLogsParseTypesAndLimitFromJTokenParameters()
+        {
+            var parameters = JObject.Parse("{\"types\":[\"error\",\"warning\"],\"limit\":1}");
+
+            var result = UnityEditorHandlers.HandleGetConsoleLogs(parameters).Result;
+            var json = DotCraftJson.Serialize(result);
+
+            Assert.That(json, Does.Contain("\"logs\""));
+        }
+    }
+}

--- a/Tests/Editor/UnityToolParameterTests.cs.meta
+++ b/Tests/Editor/UnityToolParameterTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a5d6a5f68ac44113826a95e8c9de6620
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
         "name": "DotHarness",
         "url": "https://github.com/DotHarness"
     },
-    "dependencies": {},
+    "dependencies": {
+        "com.unity.nuget.newtonsoft-json": "3.2.2"
+    },
     "samples": []
 }


### PR DESCRIPTION
- Refactor ACP extensions methods to dotcraft's dynamic tools.
- Remove System.Text.Json and Nuget For Unity dependencies, use Newtonsoft.Json instead.
- Compatiable to dotcraft v0.1.6.